### PR TITLE
Hotfix: Update README and fix broken imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
 # Oscillizer-web
 
-Jason Summers' Oscillizer implemented in Vanilla HTML5/CSS3/ES6.
+A simple static web page of Jason Summers' Oscillizer.
+
+~~Implemented in Vanilla HTML5/CSS3/ES6.~~
+
+Currently migration to TypeScript in progress.
 
 ## About
 
 [Oscillizer](https://entropymine.com/jason/life/oscillizer/)
 is a program by Jason Summers that analyzes oscillators.
 
-This is a simple web version of oscillizer
+This is a simple static web page of oscillizer
 that aims to minimize moving parts.
+
+For a working demo, see https://nightlyherb.github.io/oscillizer.
 
 ## Installation
 
 Run `npm install` to install the development dependencies.
 
-## Running the page
+## Building and running the page
 
-The entire codebase is a static webpage and lives inside `/docs`.
-Thus you can open `/docs/index.html` to see the web page.
+Before running the page you need to build it first.
+
+To build, run `npm run build:dev` for a development build,
+or `npm run build:release` for a release build.
+
+The built source should be a static webpage inside `/build`.
+Thus you can open `/build/index.html` to see the web page.
 Alternatively you can run `npm run server` to serve the page.
 
 ## Testing
 
 Currently unit tests are done via Cypress.
-Run `npm run cypress` to open the cypress client,
-or `npm run test` to just run the tests from the cli.
-
-## Documentation
-
-Currently JSDoc is used to generate documentation.
-Run `npm run jsdoc` and the docs will be in `/jsdoc`.
+In order to open the Cypress client, run `npm run cypress`.
+In order to test with Cypress cli, run `npm run server`
+and then run `npm run test` from a separate terminal.

--- a/cypress/integration/engine/RLEPatternParser.spec.js
+++ b/cypress/integration/engine/RLEPatternParser.spec.js
@@ -1,4 +1,4 @@
-import PatternParser from '../../../docs/Engine/RLE/PatternParser.js';
+import PatternParser from '../../../src/Engine/RLE/PatternParser.ts';
 
 describe('RLE Parser state', () => {
   it('should process newlines correctly', () => {

--- a/cypress/integration/engine/RLERuleParser.spec.js
+++ b/cypress/integration/engine/RLERuleParser.spec.js
@@ -1,6 +1,6 @@
-import INTRule from '../../../docs/BaseTypes/Rule/INTRule.js';
-import TotalisticRule from '../../../docs/BaseTypes/Rule/TotalisticRule.js';
-import * as RuleParser from '../../../docs/Engine/RLE/RuleParser.js';
+import INTRule from '../../../src/BaseTypes/Rule/INTRule.ts';
+import TotalisticRule from '../../../src/BaseTypes/Rule/TotalisticRule.ts';
+import * as RuleParser from '../../../src/Engine/RLE/RuleParser.ts';
 
 describe('Totalistic rule parsing', () => {
   it('should parse canonical notation correctly', () => {

--- a/cypress/integration/engine/SimpleINTBoard.spec.js
+++ b/cypress/integration/engine/SimpleINTBoard.spec.js
@@ -1,5 +1,5 @@
-import SimpleINTBoard from '../../../docs/Engine/Board/SimpleBoard/SimpleINTBoard.js';
-import INTRule from '../../../docs/BaseTypes/Rule/INTRule.js';
+import SimpleINTBoard from '../../../src/Engine/Board/SimpleBoard/SimpleINTBoard.ts';
+import INTRule from '../../../src/BaseTypes/Rule/INTRule.ts';
 
 // tlife is b3-i/s2-i34q
 const tlife = new INTRule(

--- a/cypress/integration/engine/SimpleTotalisticBoard.spec.js
+++ b/cypress/integration/engine/SimpleTotalisticBoard.spec.js
@@ -1,6 +1,6 @@
-import SimpleTotalisticBoard from '../../../docs/Engine/Board/SimpleBoard/SimpleTotalisticBoard.js';
-import TotalisticRule from '../../../docs/BaseTypes/Rule/TotalisticRule.js';
-import BoundingBox from '../../../docs/BaseTypes/BoundingBox.js';
+import SimpleTotalisticBoard from '../../../src/Engine/Board/SimpleBoard/SimpleTotalisticBoard.ts';
+import TotalisticRule from '../../../src/BaseTypes/Rule/TotalisticRule.ts';
+import BoundingBox from '../../../src/BaseTypes/BoundingBox.ts';
 
 const conwaylife = new TotalisticRule([3], [2, 3]);
 const gliderBoard = new SimpleTotalisticBoard([[1, 0], [2, 1], [0, 2], [1, 2], [2, 2]], conwaylife);

--- a/cypress/integration/lib/osc.spec.js
+++ b/cypress/integration/lib/osc.spec.js
@@ -1,6 +1,6 @@
-import * as osc from '../../../docs/MVC/Controllers/OscStatsController/OscHelpers.js';
-import TotalisticRule from '../../../docs/BaseTypes/Rule/TotalisticRule.js';
-import SimpleBoard from '../../../docs/Engine/Board/SimpleBoard/SimpleTotalisticBoard.js';
+import * as osc from '../../../src/MVC/Controllers/OscStatsController/OscHelpers.ts';
+import TotalisticRule from '../../../src/BaseTypes/Rule/TotalisticRule.ts';
+import SimpleBoard from '../../../src/Engine/Board/SimpleBoard/SimpleTotalisticBoard.ts';
 
 const conwaylife = new TotalisticRule([3], [2, 3]);
 const makeBoard = (cells) => new SimpleBoard(cells, conwaylife);

--- a/cypress/integration/lib/rle.spec.js
+++ b/cypress/integration/lib/rle.spec.js
@@ -1,4 +1,4 @@
-import * as rle from '../../../docs/MVC/Controllers/OscStatsController/RLEHelpers.js';
+import * as rle from '../../../src/MVC/Controllers/OscStatsController/RLEHelpers.ts';
 
 describe('RLE body parser', () => {
   it('should parse the glider correctly', () => {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
+  "dependencies": {},
   "devDependencies": {
     "cypress": "^8.2.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-import": "^2.23.4",
-    "http-server": "^13.0.0"
+    "http-server": "^13.0.0",
+    "esbuild": "^0.13.15",
+    "typescript": "^4.5.2"
   },
   "scripts": {
     "build:prod": "esbuild src/index.ts --outfile=build/index.js --bundle --minify --target=es6; node bin/build.js;",
@@ -13,9 +16,5 @@
     "server": "http-server build",
     "test": "cypress run",
     "cypress": "cypress open"
-  },
-  "dependencies": {
-    "esbuild": "^0.13.15",
-    "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "typescript": "^4.5.2"
   },
   "scripts": {
-    "build:prod": "esbuild src/index.ts --outfile=build/index.js --bundle --minify --target=es6; node bin/build.js;",
-    "build": "esbuild src/index.ts --outfile=build/index.js --bundle --sourcemap --target=es6; node bin/build.js;",
+    "build:release": "(esbuild src/index.ts --outfile=build/index.js --bundle --minify --target=es6) && (node bin/build.js)",
+    "build:dev": "(esbuild src/index.ts --outfile=build/index.js --bundle --sourcemap --target=es6) && (node bin/build.js)",
     "server": "http-server build",
     "test": "cypress run",
     "cypress": "cypress open"

--- a/src/AppConfig.ts
+++ b/src/AppConfig.ts
@@ -1,7 +1,7 @@
-import SimpleTotalisticBoard from './Engine/Board/SimpleBoard/SimpleTotalisticBoard.js';
-import TotalisticRule from './BaseTypes/Rule/TotalisticRule.js';
-import INTRule from './BaseTypes/Rule/INTRule.js';
-import SimpleINTBoard from './Engine/Board/SimpleBoard/SimpleINTBoard.js';
+import SimpleTotalisticBoard from './Engine/Board/SimpleBoard/SimpleTotalisticBoard';
+import TotalisticRule from './BaseTypes/Rule/TotalisticRule';
+import INTRule from './BaseTypes/Rule/INTRule';
+import SimpleINTBoard from './Engine/Board/SimpleBoard/SimpleINTBoard';
 
 const life = new TotalisticRule([3], [2, 3]);
 

--- a/src/Engine/Board/SimpleBoard/AbcSimpleBoard.ts
+++ b/src/Engine/Board/SimpleBoard/AbcSimpleBoard.ts
@@ -1,4 +1,4 @@
-import BoundingBox from '../../../BaseTypes/BoundingBox.js';
+import BoundingBox from '../../../BaseTypes/BoundingBox';
 
 /**
  * @typedef {import('../../../BaseTypes/Rule/Rule').Rule} Rule

--- a/src/Engine/Board/SimpleBoard/SimpleINTBoard.ts
+++ b/src/Engine/Board/SimpleBoard/SimpleINTBoard.ts
@@ -1,6 +1,6 @@
-import AbcSimpleBoard from './AbcSimpleBoard.js';
-import CellMap from '../../../BaseTypes/CellMap.js';
-import { intNeighborsByIndex } from '../../../BaseTypes/Neighbors/INTNeighbors.js';
+import AbcSimpleBoard from './AbcSimpleBoard';
+import CellMap from '../../../BaseTypes/CellMap';
+import { intNeighborsByIndex } from '../../../BaseTypes/Neighbors/INTNeighbors';
 
 /**
  * @typedef {import('./AbcSimpleBoard').TransitionFunction} TransitionFunction

--- a/src/Engine/Board/SimpleBoard/SimpleTotalisticBoard.ts
+++ b/src/Engine/Board/SimpleBoard/SimpleTotalisticBoard.ts
@@ -1,5 +1,5 @@
-import AbcSimpleBoard from './AbcSimpleBoard.js';
-import CellMap from '../../../BaseTypes/CellMap.js';
+import AbcSimpleBoard from './AbcSimpleBoard';
+import CellMap from '../../../BaseTypes/CellMap';
 
 const moore = [[-1, -1], [-1, 0], [-1, 1], [0, -1], [0, 0], [0, 1], [1, -1], [1, 0], [1, 1]];
 

--- a/src/Engine/RLE/RuleParser.ts
+++ b/src/Engine/RLE/RuleParser.ts
@@ -1,5 +1,5 @@
-import INTRule from '../../BaseTypes/Rule/INTRule.js';
-import TotalisticRule from '../../BaseTypes/Rule/TotalisticRule.js';
+import INTRule from '../../BaseTypes/Rule/INTRule';
+import TotalisticRule from '../../BaseTypes/Rule/TotalisticRule';
 
 /**
  * Try to parse totalistic rule from rulestring.

--- a/src/MVC/Controllers/OscStatsController/OscHelpers.ts
+++ b/src/MVC/Controllers/OscStatsController/OscHelpers.ts
@@ -1,5 +1,5 @@
-import BoundingBox from '../../../BaseTypes/BoundingBox.js';
-import CellMap from '../../../BaseTypes/CellMap.js';
+import BoundingBox from '../../../BaseTypes/BoundingBox';
+import CellMap from '../../../BaseTypes/CellMap';
 
 /**
  * Helper functions for oscillator-related functionality

--- a/src/MVC/Controllers/OscStatsController/OscStatsController.ts
+++ b/src/MVC/Controllers/OscStatsController/OscStatsController.ts
@@ -1,6 +1,6 @@
-import { parse as parseRLE } from './RLEHelpers.js';
-import { getOscStats } from './OscHelpers.js';
-import * as AppConfig from '../../../AppConfig.js';
+import { parse as parseRLE } from './RLEHelpers';
+import { getOscStats } from './OscHelpers';
+import * as AppConfig from '../../../AppConfig';
 
 /**
  * @typedef {import('../IController').IController}  IController

--- a/src/MVC/Controllers/OscStatsController/RLEHelpers.ts
+++ b/src/MVC/Controllers/OscStatsController/RLEHelpers.ts
@@ -1,5 +1,5 @@
-import PatternParser from '../../../Engine/RLE/PatternParser.js';
-import { parseINTRule, parseTotalisticRule } from '../../../Engine/RLE/RuleParser.js';
+import PatternParser from '../../../Engine/RLE/PatternParser';
+import { parseINTRule, parseTotalisticRule } from '../../../Engine/RLE/RuleParser';
 
 /** @module */
 

--- a/src/MVC/Views/OscillizerCanvasView/OscillizerCanvasView.ts
+++ b/src/MVC/Views/OscillizerCanvasView/OscillizerCanvasView.ts
@@ -1,4 +1,4 @@
-import * as CanvasHelpers from './CanvasHelpers.js';
+import * as CanvasHelpers from './CanvasHelpers';
 
 /**
  * @typedef {import('../../Models/AppState').default} AppState
@@ -6,7 +6,7 @@ import * as CanvasHelpers from './CanvasHelpers.js';
 
 const drawLiveCellOptions = new Map(
   [
-    ['none', () => {}],
+    ['none', () => { }],
     ['border', CanvasHelpers.drawLiveCellBorder],
     ['interior', CanvasHelpers.drawLiveCellInterior],
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import AppState from './MVC/Models/AppState.js';
-import EventTargetPassingController from './MVC/Controllers/PassingController/EventTargetPassingController.js';
-import OscStatsController from './MVC/Controllers/OscStatsController/OscStatsController.js';
-import OscillizerCanvasView from './MVC/Views/OscillizerCanvasView/OscillizerCanvasView.js';
-import OscStatsView from './MVC/Views/OscStatsView/OscStatsView.js';
+import AppState from './MVC/Models/AppState';
+import EventTargetPassingController from './MVC/Controllers/PassingController/EventTargetPassingController';
+import OscStatsController from './MVC/Controllers/OscStatsController/OscStatsController';
+import OscillizerCanvasView from './MVC/Views/OscillizerCanvasView/OscillizerCanvasView';
+import OscStatsView from './MVC/Views/OscStatsView/OscStatsView';
 
 const appState = {
   oscInfo: new AppState(),


### PR DESCRIPTION
1. Fix broken imports

    Due to hasty migrations some changes were not implemented properly.
    Broken imports was one of them. This broke tests.
    Now imports are all updated so that the tests can be run.

2. Update README

    The README was updated to match the current state of TypeScript migration.
    Changes include:

        - Removing JSDoc (from README)
            - TODO: remove them all and migrate to TS types.
        - Adding a build step

There is still a lot to do...